### PR TITLE
Initialize database handles in server entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,20 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { initializeDatabase } from './database/config.js';
+
+type DatabaseHandles = ReturnType<typeof initializeDatabase>;
+
+export let dbHandle: DatabaseHandles['db'] | null = null;
+export let sqliteHandle: DatabaseHandles['sqlite'] | null = null;
+
+export function getDatabaseHandles(): DatabaseHandles | null {
+  if (!dbHandle || !sqliteHandle) {
+    return null;
+  }
+
+  return { db: dbHandle, sqlite: sqliteHandle };
+}
 
 // Initialize the MCP server
 const server = new Server(
@@ -39,6 +53,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 // Start the server
 async function main() {
+  const handles = initializeDatabase();
+  dbHandle = handles.db;
+  sqliteHandle = handles.sqlite;
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error('Workout MCP Server running on stdio');


### PR DESCRIPTION
## Summary
- initialize the SQLite database when the MCP server starts
- expose exported helpers so future tools can access the database handles

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd771c43748326ac8ef0036cf32e2c