### PR TITLE
Ensure schema validation enforces foreign key pragma

### DIFF
--- a/src/__tests__/database.test.ts
+++ b/src/__tests__/database.test.ts
@@ -170,6 +170,20 @@ describe('Database Schema and Initialization', () => {
       const isValid = validateSchema(testDb);
       expect(isValid).toBe(false);
     });
+
+    it('should fail validation when foreign keys are disabled', () => {
+      // Initialize schema to ensure tables and indexes exist
+      initializeSchema(db, testDb);
+
+      // Temporarily disable foreign keys for validation
+      testDb.pragma('foreign_keys = OFF');
+
+      const isValid = validateSchema(testDb);
+      expect(isValid).toBe(false);
+
+      // Re-enable foreign keys to avoid affecting other tests
+      testDb.pragma('foreign_keys = ON');
+    });
   });
 
   describe('Table Structure', () => {

--- a/src/database/init.ts
+++ b/src/database/init.ts
@@ -120,8 +120,8 @@ export function validateSchema(sqlite: Database.Database): boolean {
     }
     
     // Verify foreign key constraints are enabled
-    const fkEnabled = sqlite.pragma('foreign_keys');
-    if (!fkEnabled) {
+    const fkEnabled = sqlite.pragma('foreign_keys', { simple: true });
+    if (fkEnabled !== 1) {
       return false;
     }
     


### PR DESCRIPTION
## Summary
- require `validateSchema` to read the `foreign_keys` pragma via the simple form and ensure it equals `1`
- add a regression test that disables foreign keys and expects schema validation to fail

## Testing
- pnpm test *(fails: native better-sqlite3 binding is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7f5018988326911bb24b340221ca