### PR TITLE
Refactor date range schemas for reusable refinement

### DIFF
--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { ZodIssueCode, ZodTypeAny, z } from 'zod';
 
 // Base validation schemas for common types
 export const PositiveNumberSchema = z.number().positive('Must be a positive number');
@@ -30,22 +30,26 @@ export const AddExerciseSetSchema = z.object({
   notes: z.string().optional()
 });
 
-// Query validation schemas
-export const DateRangeSchema = z.object({
+const BaseDateRangeObject = z.object({
   startDate: ISO8601DateTimeSchema.optional(),
   endDate: ISO8601DateTimeSchema.optional()
-}).refine(
-  (data) => {
-    if (data.startDate && data.endDate) {
-      return new Date(data.startDate) <= new Date(data.endDate);
+});
+
+const withDateRangeOrderingCheck = <T extends ZodTypeAny>(schema: T) =>
+  schema.superRefine((data, ctx) => {
+    const { startDate, endDate } = data as { startDate?: string; endDate?: string };
+
+    if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+      ctx.addIssue({
+        code: ZodIssueCode.custom,
+        message: 'Start date must be before or equal to end date',
+        path: ['endDate']
+      });
     }
-    return true;
-  },
-  {
-    message: 'Start date must be before or equal to end date',
-    path: ['endDate']
-  }
-);
+  });
+
+// Query validation schemas
+export const DateRangeSchema = withDateRangeOrderingCheck(BaseDateRangeObject);
 
 export const ExerciseHistorySchema = z.object({
   exerciseName: NonEmptyStringSchema,
@@ -58,38 +62,27 @@ export const WorkoutQuerySchema = z.object({
 
 export const GetWorkoutsSchema = DateRangeSchema;
 
-// Base schema for date range filtering
-const BaseDateRangeSchema = z.object({
-  startDate: ISO8601DateTimeSchema.optional(),
-  endDate: ISO8601DateTimeSchema.optional()
-}).refine(
-  (data) => {
-    if (data.startDate && data.endDate) {
-      return new Date(data.startDate) <= new Date(data.endDate);
-    }
-    return true;
-  },
-  {
-    message: 'Start date must be before or equal to end date',
-    path: ['endDate']
-  }
+// Calculation filter schemas
+export const VolumeCalculationSchema = withDateRangeOrderingCheck(
+  z.object({
+    exerciseName: z.string().optional(),
+    workoutId: PositiveIntegerSchema.optional()
+  }).merge(BaseDateRangeObject)
 );
 
-// Calculation filter schemas
-export const VolumeCalculationSchema = z.object({
-  exerciseName: z.string().optional(),
-  workoutId: PositiveIntegerSchema.optional()
-}).merge(BaseDateRangeSchema);
+export const AverageWeightSchema = withDateRangeOrderingCheck(
+  z.object({
+    exerciseName: NonEmptyStringSchema
+  }).merge(BaseDateRangeObject)
+);
 
-export const AverageWeightSchema = z.object({
-  exerciseName: NonEmptyStringSchema
-}).merge(BaseDateRangeSchema);
-
-export const CountSetsSchema = z.object({
-  exerciseName: z.string().optional(),
-  workoutId: PositiveIntegerSchema.optional(),
-  completed: z.boolean().optional()
-}).merge(BaseDateRangeSchema);
+export const CountSetsSchema = withDateRangeOrderingCheck(
+  z.object({
+    exerciseName: z.string().optional(),
+    workoutId: PositiveIntegerSchema.optional(),
+    completed: z.boolean().optional()
+  }).merge(BaseDateRangeObject)
+);
 
 // Export type definitions for TypeScript
 export type StartWorkoutInput = z.infer<typeof StartWorkoutSchema>;

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,4 +1,4 @@
-import { ZodIssueCode, ZodTypeAny, z } from 'zod';
+import { ZodIssueCode, z } from 'zod';
 
 // Base validation schemas for common types
 export const PositiveNumberSchema = z.number().positive('Must be a positive number');
@@ -30,14 +30,21 @@ export const AddExerciseSetSchema = z.object({
   notes: z.string().optional()
 });
 
+type DateRangeLike = {
+  startDate?: string;
+  endDate?: string;
+};
+
 const BaseDateRangeObject = z.object({
   startDate: ISO8601DateTimeSchema.optional(),
   endDate: ISO8601DateTimeSchema.optional()
 });
 
-const withDateRangeOrderingCheck = <T extends ZodTypeAny>(schema: T) =>
+const withDateRangeOrderingCheck = <Output extends DateRangeLike, Def extends z.ZodTypeDef = z.ZodTypeDef, Input = Output>(
+  schema: z.ZodType<Output, Def, Input>
+) =>
   schema.superRefine((data, ctx) => {
-    const { startDate, endDate } = data as { startDate?: string; endDate?: string };
+    const { startDate, endDate } = data;
 
     if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
       ctx.addIssue({


### PR DESCRIPTION
## Summary
- extract a reusable `BaseDateRangeObject` holding the raw start/end date fields
- add a shared helper that re-applies the start/end ordering refinement and reuse it across all date-range schemas

## Testing
- pnpm test -- validation *(fails: Preset ts-jest/presets/default-esm not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9afd3dc08326921a38500ba89a37