### PR TITLE
Fix date range refinement typing for Zod v4

### DIFF
--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -40,11 +40,9 @@ const BaseDateRangeObject = z.object({
   endDate: ISO8601DateTimeSchema.optional()
 });
 
-const withDateRangeOrderingCheck = <Output extends DateRangeLike, Def extends z.ZodTypeDef = z.ZodTypeDef, Input = Output>(
-  schema: z.ZodType<Output, Def, Input>
-) =>
+const withDateRangeOrderingCheck = <T extends z.ZodTypeAny>(schema: T) =>
   schema.superRefine((data, ctx) => {
-    const { startDate, endDate } = data;
+    const { startDate, endDate } = data as DateRangeLike;
 
     if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
       ctx.addIssue({


### PR DESCRIPTION
## Summary
- simplify the date range ordering helper to avoid usage of removed ZodTypeDef export
- ensure the refinement logic casts to the expected DateRangeLike shape

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cda27089c88326bfb5e1ccabc58f78